### PR TITLE
Add proxy online detection support to silently ignore offline proxies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,9 +6,9 @@ Changelog
 **debops.apt_proxy**
 
 This project adheres to `Semantic Versioning <http://semver.org/spec/v2.0.0.html>`__
-and `human-readable changelog <http://keepachangelog.com/en/0.3.0/>`__.
+and `human-readable changelog <http://keepachangelog.com/en/1.0.0/>`__.
 
-The current role maintainer_ is drybjed.
+The current role maintainer_ is drybjed_.
 
 
 `debops.apt_proxy master`_ - unreleased

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,16 @@ The current role maintainer_ is drybjed_.
 
 .. _debops.apt_proxy master: https://github.com/debops/ansible-apt_proxy/compare/v0.1.0...master
 
+Added
+~~~~~
+
+- Add proxy online detection support to silently skip/ignore temporally offline proxies.
+  The main use case for this feature are workstations and home servers which
+  might not always be able to reach the proxy server but should still be able
+  to update/install packages.
+  It is therefore disabled by default which is probably the best setting for
+  production data center environments. [ypid_]
+
 
 debops.apt_proxy v0.1.0 - 2016-09-14
 ------------------------------------

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,6 +1,7 @@
 debops.apt_proxy - Manage HTTP/HTTPS/FTP proxy for APT with Ansible
 
 Copyright (C) 2016-2017 Maciej Delmanowski <drybjed@gmail.com>
+Copyright (C) 2016-2017 Robin Schneider <ypid@riseup.net>
 Copyright (C) 2016-2017 DebOps https://debops.org/
 
 This program is free software; you can redistribute it and/or modify

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,7 +1,7 @@
 debops.apt_proxy - Manage HTTP/HTTPS/FTP proxy for APT with Ansible
 
-Copyright (C) 2016 Maciej Delmanowski <drybjed@gmail.com>
-Copyright (C) 2016 DebOps https://debops.org/
+Copyright (C) 2016-2017 Maciej Delmanowski <drybjed@gmail.com>
+Copyright (C) 2016-2017 DebOps https://debops.org/
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License version 3, as

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ This role manages the HTTP/HTTPS/FTP proxy configuration for APT. You can
 define what proxy to use, what hosts should be connected to directly, as well
 as set additional APT configuration options related to proxies as needed.
 
+The role also features proxy online detection support to silently
+skip/ignore temporally offline proxies which can make sense for
+workstations and home servers.
+
 ### Installation
 
 This role requires at least Ansible `v2.0.0`. To install it, run:
@@ -42,6 +46,7 @@ into your playbook.
 ### Authors and license
 
 - [Maciej Delmanowski](https://docs.debops.org/en/latest/debops-keyring/docs/entities.html#debops-keyring-entity-drybjed) (maintainer) | [e-mail](mailto:drybjed@gmail.com) | [Twitter](https://twitter.com/drybjed) | [GitHub](https://github.com/drybjed)
+- [Robin Schneider](https://docs.debops.org/en/latest/debops-keyring/docs/entities.html#debops-keyring-entity-ypid) | [e-mail](mailto:ypid@riseup.net) | [GitHub](https://github.com/ypid)
 
 License: [GPL-3.0](https://tldrlegal.com/license/gnu-general-public-license-v3-%28gpl-3%29)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,18 @@
 # .. include:: includes/all.rst
 
 
+# Required packages [[[
+# ---------------------
+
+# .. envvar:: apt_proxy__base_packages [[[
+#
+# List of base packages to install.
+apt_proxy__base_packages:
+  - '{{ [ "python3-future", "python3-apt"  ]
+        if (apt_proxy__temporally_avoid_unreachable|bool)
+        else [] }}'
+                                                                   # ]]]
+                                                                   # ]]]
 # Main configuration [[[
 # ----------------------
 
@@ -140,6 +152,27 @@ apt_proxy__ftp_login:
 #      'Proxy::Passive": 'true'
 #
 apt_proxy__ftp_options: {}
+                                                                   # ]]]
+                                                                   # ]]]
+# Proxy online detection [[[
+# --------------------------
+
+# By default (Debian, DebOps), APT will fail when the configured proxy can not
+# be reached.
+#
+# DebOps provides a script which hooks into APT using a
+# `Acquire::HTTP::Proxy-Auto-Detect` script which checks if the proxy is
+# currently reachable.
+# With this, APT will fall back to "DIRECT" (no proxy) if the proxy
+# is (temporally) not reachable.
+
+# .. envvar:: apt_proxy__temporally_avoid_unreachable [[[
+#
+# Configures the behaviour if the proxy is not reachable.
+# ``True`` will cause APT to silently ignore offline proxies.
+# ``False`` will cause APT to return with an error if the proxy is offline.
+# This is currently only supported for HTTPS and HTTP proxies.
+apt_proxy__temporally_avoid_unreachable: False
                                                                    # ]]]
                                                                    # ]]]
                                                                    # ]]]

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -37,9 +37,9 @@ Ansible tags
 ------------
 
 You can use Ansible ``--tags`` or ``--skip-tags`` parameters to limit what
-tasks are performed during Ansible run. This can be used after host is first
+tasks are performed during Ansible run. This can be used after a host was first
 configured to speed up playbook execution, when you are sure that most of the
-configuration has not been changed.
+configuration is already in the desired state.
 
 Available role tags:
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -5,6 +5,10 @@ This role manages the HTTP/HTTPS/FTP proxy configuration for APT. You can
 define what proxy to use, what hosts should be connected to directly, as well
 as set additional APT configuration options related to proxies as needed.
 
+The role also features proxy online detection support to silently
+skip/ignore temporally offline proxies which can make sense for
+workstations and home servers.
+
 
 Installation
 ~~~~~~~~~~~~

--- a/files/usr/local/lib/get-reachable-apt-proxy
+++ b/files/usr/local/lib/get-reachable-apt-proxy
@@ -25,7 +25,7 @@ is (temporally) not reachable.
 
 To use this script, set:
 
-    Acquire::HTTP::Proxy-Auto-Detect "/usr/local/sbin/get-reachable-apt-proxy";
+    Acquire::HTTP::Proxy-Auto-Detect "/usr/local/lib/get-reachable-apt-proxy";
 
 in your APT configuration.
 """

--- a/files/usr/local/sbin/get-reachable-apt-proxy
+++ b/files/usr/local/sbin/get-reachable-apt-proxy
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2017 Robin Schneider <ypid@riseup.net>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, version 3 of the
+# License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Check if the proxy specified as Acquire::HTTP::Proxy or Acquire::HTTPS::Proxy
+are currently reachable before promoting them to be used by the currently
+running apt process. Without this script, apt will fail when the proxy can not be reached.
+With this script, apt silently falls back to "DIRECT" (no proxy) if the proxy
+is (temporally) not reachable.
+
+To use this script, set:
+
+    Acquire::HTTP::Proxy-Auto-Detect "/usr/local/sbin/get-reachable-apt-proxy";
+
+in your APT configuration.
+"""
+
+from __future__ import print_function, unicode_literals, absolute_import, division
+
+__license__ = 'AGPL-3.0'
+__author__ = 'Robin Schneider <ypid@riseup.net>'
+__version__ = '0.1.0'
+
+from future.standard_library import install_aliases
+
+install_aliases()
+
+import argparse
+import logging
+
+from urllib.parse import urlparse
+from urllib.request import urlopen
+from urllib.error import URLError, HTTPError
+
+import apt_pkg
+
+LOG = logging.getLogger(__name__)
+
+
+def get_first_up_proxy(target_uri_raw):
+    possible_proxies = []
+
+    LOG.debug("Trying to find proxy for URI: {}".format(target_uri_raw))
+
+    target_uri = urlparse(target_uri_raw)
+
+    apt_config_key = "Acquire::{}::Proxy".format(
+        target_uri.scheme.upper()
+    )
+
+    if apt_pkg.config.exists(apt_config_key):
+        proxy_uris = apt_pkg.config.get(apt_config_key)
+        for proxy_uri_raw in proxy_uris.split(' '):
+
+            if proxy_uri_raw.upper() in ['DIRECT']:
+                LOG.debug("Skipping special proxy keyword: {}".format(proxy_uri_raw))
+                continue
+            else:
+                LOG.debug("Checking possible proxy URI: {}".format(proxy_uri_raw))
+
+            proxy_uri = urlparse(proxy_uri_raw)
+
+            if proxy_uri.scheme in ['https', 'http']:
+                try:
+                    urlopen(proxy_uri_raw)
+                except HTTPError as err:
+                    LOG.debug("Proxy responded with: {}".format(err))
+                    pass
+                except URLError as err:
+                    LOG.debug("Proxy not suitable: {}".format(err))
+                    continue
+
+                LOG.info("Adding proxy to list of possible proxies: {}".format(proxy_uri_raw))
+                possible_proxies.append(proxy_uri_raw)
+                break
+            else:
+                raise NotImplementedError("URI scheme {} is not yet implemented.".format(
+
+                ))
+
+    possible_proxies.append('DIRECT')
+
+    return possible_proxies[0]
+
+
+def get_args_parser():
+    args_parser = argparse.ArgumentParser(
+        prog='get-reachable-apt-proxy',
+        epilog=__doc__,
+    )
+    args_parser.add_argument(
+        '-V', '--version',
+        action='version',
+        version=__version__,
+    )
+    args_parser.add_argument(
+        '-d', '--debug',
+        help="Write debugging and higher to STDOUT|STDERR.",
+        action="store_const",
+        dest="loglevel",
+        const=logging.DEBUG,
+    )
+    args_parser.add_argument(
+        '-v', '--verbose',
+        help="Write information and higher to STDOUT|STDERR.",
+        action="store_const",
+        dest="loglevel",
+        const=logging.INFO,
+    )
+    args_parser.add_argument(
+        'uri',
+    )
+
+    return args_parser
+
+
+def main():
+    args_parser = get_args_parser()
+    args_parser.set_defaults(loglevel=logging.WARN)
+    args = args_parser.parse_args()
+
+    logging.basicConfig(
+        format='%(levelname)s{}, %(asctime)s: %(message)s'.format(
+            ' (%(filename)s:%(lineno)s)' if args.loglevel <= logging.DEBUG else '',
+        ),
+        level=args.loglevel,
+    )
+
+    apt_pkg.init_config()
+    print(get_first_up_proxy(args.uri))
+
+
+if __name__ == '__main__':
+    main()

--- a/meta/ansigenome.yml
+++ b/meta/ansigenome.yml
@@ -15,7 +15,15 @@ ansigenome_info:
       twitter: 'drybjed'
       github: 'drybjed'
 
+    - name:  'Robin Schneider'
+      email: 'ypid@riseup.net'
+      github: 'ypid'
+
   synopsis: |
     This role manages the HTTP/HTTPS/FTP proxy configuration for APT. You can
     define what proxy to use, what hosts should be connected to directly, as well
     as set additional APT configuration options related to proxies as needed.
+
+    The role also features proxy online detection support to silently
+    skip/ignore temporally offline proxies which can make sense for
+    workstations and home servers.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@
 dependencies: []
 
 galaxy_info:
-  author: 'Maciej Delmanowski'
+  author: 'Maciej Delmanowski, Robin Schneider'
   description: 'Manage APT proxy configuration'
   company: 'DebOps'
   license: 'GPL-3.0'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,23 @@
 ---
 
+- name: Install requested system packages
+  package:
+    name: '{{ item }}'
+    state: 'present'
+  when: apt_proxy__deploy_state == 'present' and apt_proxy__temporally_avoid_unreachable|bool
+  with_flattened:
+    - '{{ apt_proxy__base_packages }}'
+
+- name: Copy get-reachable-apt-proxy to remote host
+  copy:
+    dest:     '/usr/local/sbin/get-reachable-apt-proxy'
+    src:      'usr/local/sbin/get-reachable-apt-proxy'
+    validate: '%s "https://example.org/"'
+    owner:    'root'
+    group:    'root'
+    mode:     '0755'
+  when: apt_proxy__deploy_state == 'present' and apt_proxy__temporally_avoid_unreachable|bool
+
 - name: Remove APT proxy configuration
   file:
     path: '/etc/apt/apt.conf.d/{{ apt_proxy__filename }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,8 +10,8 @@
 
 - name: Copy get-reachable-apt-proxy to remote host
   copy:
-    dest:     '/usr/local/sbin/get-reachable-apt-proxy'
-    src:      'usr/local/sbin/get-reachable-apt-proxy'
+    dest:     '/usr/local/lib/get-reachable-apt-proxy'
+    src:      'usr/local/lib/get-reachable-apt-proxy'
     validate: '%s "https://example.org/"'
     owner:    'root'
     group:    'root'

--- a/templates/etc/apt/apt.conf.d/apt_proxy.conf.j2
+++ b/templates/etc/apt/apt.conf.d/apt_proxy.conf.j2
@@ -3,7 +3,7 @@
 {% if apt_proxy__http_url %}
 Acquire::HTTP {
 {%   if apt_proxy__temporally_avoid_unreachable|bool %}
-  Proxy-Auto-Detect "/usr/local/sbin/get-reachable-apt-proxy";
+  Proxy-Auto-Detect "/usr/local/lib/get-reachable-apt-proxy";
 {%   endif %}
   Proxy "{{ apt_proxy__http_url }}";
 {%   if apt_proxy__http_direct %}
@@ -18,12 +18,12 @@ Acquire::HTTP {
 {%   endif %}
 };
 {% elif apt_proxy__temporally_avoid_unreachable|bool %}
-Acquire::HTTP::Proxy-Auto-Detect "/usr/local/sbin/get-reachable-apt-proxy";
+Acquire::HTTP::Proxy-Auto-Detect "/usr/local/lib/get-reachable-apt-proxy";
 {% endif %}
 {% if apt_proxy__https_url %}
 Acquire::HTTPS {
 {%   if apt_proxy__temporally_avoid_unreachable|bool %}
-  Proxy-Auto-Detect "/usr/local/sbin/get-reachable-apt-proxy";
+  Proxy-Auto-Detect "/usr/local/lib/get-reachable-apt-proxy";
 {%   endif %}
   Proxy "{{ apt_proxy__https_url }}";
 {%   if apt_proxy__https_direct %}
@@ -38,7 +38,7 @@ Acquire::HTTPS {
 {%   endif %}
 };
 {% elif apt_proxy__temporally_avoid_unreachable|bool %}
-Acquire::HTTPS::Proxy-Auto-Detect "/usr/local/sbin/get-reachable-apt-proxy";
+Acquire::HTTPS::Proxy-Auto-Detect "/usr/local/lib/get-reachable-apt-proxy";
 {% endif %}
 {% if apt_proxy__ftp_url %}
 Acquire::FTP {

--- a/templates/etc/apt/apt.conf.d/apt_proxy.conf.j2
+++ b/templates/etc/apt/apt.conf.d/apt_proxy.conf.j2
@@ -2,6 +2,9 @@
 
 {% if apt_proxy__http_url %}
 Acquire::HTTP {
+{%   if apt_proxy__temporally_avoid_unreachable|bool %}
+  Proxy-Auto-Detect "/usr/local/sbin/get-reachable-apt-proxy";
+{%   endif %}
   Proxy "{{ apt_proxy__http_url }}";
 {%   if apt_proxy__http_direct %}
 {%     for host in apt_proxy__http_direct %}
@@ -14,9 +17,14 @@ Acquire::HTTP {
 {%     endfor %}
 {%   endif %}
 };
+{% elif apt_proxy__temporally_avoid_unreachable|bool %}
+Acquire::HTTP::Proxy-Auto-Detect "/usr/local/sbin/get-reachable-apt-proxy";
 {% endif %}
 {% if apt_proxy__https_url %}
 Acquire::HTTPS {
+{%   if apt_proxy__temporally_avoid_unreachable|bool %}
+  Proxy-Auto-Detect "/usr/local/sbin/get-reachable-apt-proxy";
+{%   endif %}
   Proxy "{{ apt_proxy__https_url }}";
 {%   if apt_proxy__https_direct %}
 {%     for host in apt_proxy__https_direct %}
@@ -29,6 +37,8 @@ Acquire::HTTPS {
 {%     endfor %}
 {%   endif %}
 };
+{% elif apt_proxy__temporally_avoid_unreachable|bool %}
+Acquire::HTTPS::Proxy-Auto-Detect "/usr/local/sbin/get-reachable-apt-proxy";
 {% endif %}
 {% if apt_proxy__ftp_url %}
 Acquire::FTP {


### PR DESCRIPTION
It might also be beneficial to upstream the script to Debian. There are other similar packages like `auto-apt-proxy` (and `squid-deb-proxy-client`). Especially `auto-apt-proxy` would be interesting. The script could be extended to also provide the functionality of the current auto-apt-proxy script and then auto-apt-proxy could switch to my script.