### PR TITLE
Add `apt_proxy__proxy_auto_detect` to increase flexibility

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -174,5 +174,14 @@ apt_proxy__ftp_options: {}
 # This is currently only supported for HTTPS and HTTP proxies.
 apt_proxy__temporally_avoid_unreachable: False
                                                                    # ]]]
+
+# .. envvar:: apt_proxy__proxy_auto_detect [[[
+#
+# Value to set as `Acquire::HTTP::Proxy-Auto-Detect`. Set to `{{ omit }}` to
+# avoid setting it.
+apt_proxy__proxy_auto_detect: '{{ "/usr/local/lib/get-reachable-apt-proxy"
+                                  if (apt_proxy__temporally_avoid_unreachable|bool)
+                                  else omit }}'
+                                                                   # ]]]
                                                                    # ]]]
                                                                    # ]]]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: Copy get-reachable-apt-proxy to remote host
   copy:
-    dest:     '/usr/local/lib/get-reachable-apt-proxy'
+    dest:     '{{ apt_proxy__proxy_auto_detect }}'
     src:      'usr/local/lib/get-reachable-apt-proxy'
     validate: '%s "https://example.org/"'
     owner:    'root'

--- a/templates/etc/apt/apt.conf.d/apt_proxy.conf.j2
+++ b/templates/etc/apt/apt.conf.d/apt_proxy.conf.j2
@@ -2,8 +2,8 @@
 
 {% if apt_proxy__http_url %}
 Acquire::HTTP {
-{%   if apt_proxy__temporally_avoid_unreachable|bool %}
-  Proxy-Auto-Detect "/usr/local/lib/get-reachable-apt-proxy";
+{%   if apt_proxy__proxy_auto_detect != omit %}
+  Proxy-Auto-Detect "{{ apt_proxy__proxy_auto_detect }}";
 {%   endif %}
   Proxy "{{ apt_proxy__http_url }}";
 {%   if apt_proxy__http_direct %}
@@ -17,13 +17,13 @@ Acquire::HTTP {
 {%     endfor %}
 {%   endif %}
 };
-{% elif apt_proxy__temporally_avoid_unreachable|bool %}
-Acquire::HTTP::Proxy-Auto-Detect "/usr/local/lib/get-reachable-apt-proxy";
+{% elif apt_proxy__proxy_auto_detect != omit %}
+Acquire::HTTP::Proxy-Auto-Detect "{{ apt_proxy__proxy_auto_detect }}";
 {% endif %}
 {% if apt_proxy__https_url %}
 Acquire::HTTPS {
-{%   if apt_proxy__temporally_avoid_unreachable|bool %}
-  Proxy-Auto-Detect "/usr/local/lib/get-reachable-apt-proxy";
+{%   if apt_proxy__proxy_auto_detect != omit %}
+  Proxy-Auto-Detect "{{ apt_proxy__proxy_auto_detect }}";
 {%   endif %}
   Proxy "{{ apt_proxy__https_url }}";
 {%   if apt_proxy__https_direct %}
@@ -37,8 +37,8 @@ Acquire::HTTPS {
 {%     endfor %}
 {%   endif %}
 };
-{% elif apt_proxy__temporally_avoid_unreachable|bool %}
-Acquire::HTTPS::Proxy-Auto-Detect "/usr/local/lib/get-reachable-apt-proxy";
+{% elif apt_proxy__proxy_auto_detect != omit %}
+Acquire::HTTPS::Proxy-Auto-Detect "{{ apt_proxy__proxy_auto_detect }}";
 {% endif %}
 {% if apt_proxy__ftp_url %}
 Acquire::FTP {


### PR DESCRIPTION
Needed for better Qubes OS support.

Related to: https://github.com/debops/ansible-apt_proxy/pull/2